### PR TITLE
monkey patch to make oauth2 use a proxy agent.

### DIFF
--- a/lib/passport-predix-oauth/strategy.js
+++ b/lib/passport-predix-oauth/strategy.js
@@ -5,10 +5,10 @@ var util = require('util'),
 
 function Strategy(options, verify) {
     options = options || {};
- 
+
     options.authorizationURL = options.authorizationURL+'/oauth/authorize';
     options.tokenURL = options.tokenURL+'/oauth/token';
- 
+
     //Send clientID & clientSecret in 'Authorization' header
     var auth = 'Basic ' + new Buffer(options.clientID + ':' + options.clientSecret).toString('base64');
     options.customHeaders = {
@@ -24,6 +24,18 @@ function Strategy(options, verify) {
     this.name = 'predix';
 
     this._oauth2.setAuthMethod('Bearer');
+
+    // This is a "monkey patch" to fix the oauth2._executeRequest to work with a proxy.
+    //  hopefully they'll fix this one day, in the oauth2 package.
+    var originalExecuteRequest = this._oauth2._executeRequest;
+    this._oauth2._executeRequest = function( http_library, options, post_body, callback ) {
+      var HttpsProxyAgent = require('https-proxy-agent');
+      if (process.env['https_proxy']) {
+        httpsProxyAgent = new HttpsProxyAgent(process.env['https_proxy']);
+      }
+      options.agent = httpsProxyAgent;
+      return originalExecuteRequest( http_library, options, post_body, callback);
+    };
 
     //FIXME: needs to change to the right url
     this._userProfileURI = 'https://11ccb14b-0a4d-4e1e-ace0-9f6bbcbbe83a.predix-uaa.run.aws-usw02-pr.ice.predix.io/userinfo';

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./lib/passport-predix-oauth",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth": "0.1.x",
+    "https-proxy-agent": "^1.0.0"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
This is a pretty ugly hack, but it makes this passport strategy work from behind a corporate proxy.  I'll try to make a PR to the oauth2 package, so this hack would no longer be required.
